### PR TITLE
Fix bugs found in ZK addon components review

### DIFF
--- a/src/main/java/tools/dynamia/zk/LazyJSONObject.java
+++ b/src/main/java/tools/dynamia/zk/LazyJSONObject.java
@@ -18,6 +18,7 @@ package tools.dynamia.zk;
 import org.zkoss.json.JSONObject;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -43,6 +44,9 @@ public class LazyJSONObject extends JSONObject {
             Class clazz = getClass();
             loadClassFields(fields, clazz);
             for (Field field : fields) {
+                if (Modifier.isTransient(field.getModifiers()) || Modifier.isStatic(field.getModifiers())) {
+                    continue;
+                }
                 field.setAccessible(true);
                 Object fieldValue = field.get(this);
                 if (fieldValue != null) {

--- a/src/main/java/tools/dynamia/zk/ui/Alert.java
+++ b/src/main/java/tools/dynamia/zk/ui/Alert.java
@@ -120,7 +120,9 @@ public class Alert extends Div {
             }
 
             setZclass("alert alert-dismissible " + sclass);
-            setIconSclass(icon);
+            if (icon != null) {
+                setIconSclass(icon);
+            }
         }
     }
 

--- a/src/main/java/tools/dynamia/zk/ui/Booleanbox.java
+++ b/src/main/java/tools/dynamia/zk/ui/Booleanbox.java
@@ -19,7 +19,6 @@ package tools.dynamia.zk.ui;
 
 import org.zkoss.zul.AbstractListModel;
 import org.zkoss.zul.Combobox;
-import org.zkoss.zul.Comboitem;
 import org.zkoss.zul.ComboitemRenderer;
 import tools.dynamia.zk.ZKModelsUtils;
 
@@ -39,7 +38,8 @@ public class Booleanbox extends Combobox {
     }
 
     public Booleanbox(Boolean value) {
-        this.selected = value;
+        init();
+        setSelected(value);
     }
 
     public void init() {
@@ -80,7 +80,10 @@ public class Booleanbox extends Combobox {
         this.selected = selected;
 
         if (getModel() instanceof AbstractListModel model) {
-            Optional result = getItems().stream().filter(c -> Objects.equals(c.getValue(), selected)).map(Comboitem::getValue).findFirst();
+            Optional<BooleanWrapper> result = getItems().stream()
+                    .map(item -> (BooleanWrapper) item.getValue())
+                    .filter(wrapper -> Objects.equals(wrapper.value, selected))
+                    .findFirst();
             if (result.isPresent()) {
                 //noinspection unchecked
                 model.addToSelection(result.get());

--- a/src/main/java/tools/dynamia/zk/ui/Card.java
+++ b/src/main/java/tools/dynamia/zk/ui/Card.java
@@ -88,9 +88,13 @@ public class Card extends DivContainer {
 
     public void setColor(String color) {
         if (!Objects.equals(this.color, color)) {
-            this.removeSclass(SCLASS_PREFIX + color);
+            if (this.color != null) {
+                this.removeSclass(SCLASS_PREFIX + this.color);
+            }
             this.color = color;
-            this.addSclass(SCLASS_PREFIX + color);
+            if (this.color != null) {
+                this.addSclass(SCLASS_PREFIX + this.color);
+            }
         }
     }
 

--- a/src/main/java/tools/dynamia/zk/ui/EnumLabel.java
+++ b/src/main/java/tools/dynamia/zk/ui/EnumLabel.java
@@ -48,7 +48,7 @@ public class EnumLabel extends Label implements LoadableOnly {
     public void setEnum(Enum enumValue) {
         if (!Objects.equals(this.enumValue, enumValue)) {
             this.enumValue = enumValue;
-            setValue(clear(enumValue.toString()));
+            setValue(enumValue != null ? clear(enumValue.toString()) : null);
         }
 
     }

--- a/src/main/java/tools/dynamia/zk/ui/Keypad.java
+++ b/src/main/java/tools/dynamia/zk/ui/Keypad.java
@@ -77,6 +77,7 @@ public class Keypad extends Div {
     }
 
     public void init() {
+        getChildren().clear();
         setSclass("keypad");
         setStyle("overflow: hidden");
 

--- a/src/main/java/tools/dynamia/zk/ui/LocaleCombobox.java
+++ b/src/main/java/tools/dynamia/zk/ui/LocaleCombobox.java
@@ -66,7 +66,7 @@ public class LocaleCombobox extends Combobox {
     }
 
     public void setSelected(String selected) {
-        if (selected != this.selected) {
+        if (!Objects.equals(selected, this.selected)) {
             this.selected = selected;
             try {
                 String[] parts = selected.split("-");

--- a/src/main/java/tools/dynamia/zk/ui/SimpleCombobox.java
+++ b/src/main/java/tools/dynamia/zk/ui/SimpleCombobox.java
@@ -62,7 +62,7 @@ public class SimpleCombobox extends Combobox {
         if (getSelectedItem() != null) {
             selected = getSelectedItem().getValue();
         }
-        return selected.getValue();
+        return selected != null ? selected.getValue() : null;
     }
 
     public void setSelected(SimpleItem selected) {

--- a/src/main/java/tools/dynamia/zk/ui/TimeZoneCombobox.java
+++ b/src/main/java/tools/dynamia/zk/ui/TimeZoneCombobox.java
@@ -27,6 +27,7 @@ import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 public class TimeZoneCombobox extends Combobox {
@@ -78,7 +79,7 @@ public class TimeZoneCombobox extends Combobox {
     }
 
     public void setSelected(String selected) {
-        if (selected != this.selected) {
+        if (!Objects.equals(selected, this.selected)) {
             this.selected = selected;
             try {
                 ListModelList model = (ListModelList) getModel();

--- a/src/main/java/tools/dynamia/zk/ui/chartjs/CategoryChartjsData.java
+++ b/src/main/java/tools/dynamia/zk/ui/chartjs/CategoryChartjsData.java
@@ -31,9 +31,10 @@ public class CategoryChartjsData extends ChartjsData {
 
     public CategoryChartjsData add(String label, Number value, String backgroundColor) {
         addLabel(label);
-        dataset.addData(value);
         if (backgroundColor != null && !backgroundColor.isEmpty()) {
-            dataset.addBackgroundColor(backgroundColor);
+            dataset.addData(value, backgroundColor);
+        } else {
+            dataset.addData(value);
         }
         return this;
     }

--- a/src/main/java/tools/dynamia/zk/ui/chartjs/ChartjsData.java
+++ b/src/main/java/tools/dynamia/zk/ui/chartjs/ChartjsData.java
@@ -20,6 +20,7 @@ import tools.dynamia.zk.LazyJSONObject;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -50,9 +51,7 @@ public class ChartjsData extends LazyJSONObject {
 
     public void setLabels(String... labels) {
         if (labels != null) {
-            for (String label : labels) {
-                this.labels.add(label);
-            }
+            this.labels = new ArrayList<>(Arrays.asList(labels));
             propertyChangeSupport.firePropertyChange("labels", null, this.labels);
         }
     }

--- a/src/main/java/tools/dynamia/zk/ui/chartjs/Dataset.java
+++ b/src/main/java/tools/dynamia/zk/ui/chartjs/Dataset.java
@@ -64,7 +64,7 @@ public class Dataset<T> extends LazyJSONObject {
     private String xAxisID;
     private String yAxisID;
 
-    private ChartjsColorPalette colorPalette = new ChartjsColorPalette();
+    private transient ChartjsColorPalette colorPalette = new ChartjsColorPalette();
 
 
     public Dataset() {
@@ -138,6 +138,15 @@ public class Dataset<T> extends LazyJSONObject {
         return this;
     }
 
+    public Dataset<T> addData(T data, String backgroundColor) {
+        if (this.data == null) {
+            this.data = new ArrayList<T>();
+        }
+        this.data.add(data);
+        addBackgroundColor(backgroundColor);
+        return this;
+    }
+
     public List<String> getBackgroundColors() {
         return backgroundColors;
     }
@@ -153,7 +162,7 @@ public class Dataset<T> extends LazyJSONObject {
     }
 
     public int getBorderWidth() {
-        return borderWidth;
+        return borderWidth != null ? borderWidth : 0;
     }
 
     public Dataset<T> setBorderWidth(int borderWidth) {
@@ -186,7 +195,7 @@ public class Dataset<T> extends LazyJSONObject {
     }
 
     public boolean isHidden() {
-        return hidden;
+        return hidden != null && hidden;
     }
 
     public void setHidden(boolean hidden) {
@@ -223,7 +232,7 @@ public class Dataset<T> extends LazyJSONObject {
     }
 
     public int getPointBorderWidth() {
-        return pointBorderWidth;
+        return pointBorderWidth != null ? pointBorderWidth : 0;
     }
 
     public Dataset<T> setPointBorderWidth(int pointBorderWidth) {


### PR DESCRIPTION
## Summary

Fixes for 12 bugs found during a review of the ZK component compositions (`tools.dynamia.zk.ui` and `tools.dynamia.zk.ui.chartjs`), several of them verified by actually running the affected code paths.

**Critical (broke chart rendering, verified by execution):**
- `Dataset`: the `colorPalette` field (a plain POJO, not JSON-safe) was being swept into the chart JSON by `LazyJSONObject`'s reflective `init()`, producing an unquoted `Object.toString()` value that made the whole chart config invalid JSON on the client. Fixed by making `LazyJSONObject.init()` skip `transient`/`static` fields and marking `colorPalette` as `transient`.
- `Dataset.addData()` / `CategoryChartjsData.add(label, value, backgroundColor)`: calling `add(...)` with an explicit background color always *also* pulled an automatic color from the palette, doubling and misaligning `backgroundColors` relative to the data points. Added a non-auto-coloring `addData(T, String)` overload and used it when an explicit color is supplied.

**High (NullPointerException / broken behavior):**
- `Dataset.getBorderWidth()`, `getPointBorderWidth()`, `isHidden()`: unboxed a nullable `Integer`/`Boolean` field as a primitive, throwing NPE before the value was ever set.
- `Booleanbox(Boolean)` constructor never called `init()`, leaving the combobox with no model/renderer.
- `Booleanbox.setSelected(Boolean)` compared a `BooleanWrapper` (the item's value) against a raw `Boolean` with `Objects.equals`, which could never match — the visual selection was never applied.
- `SimpleCombobox.getSelected()` threw NPE when nothing had ever been selected.
- `Card.setColor(String)` removed the *new* color's sclass instead of the *previous* one, so switching colors stacked CSS classes instead of replacing them.
- `EnumLabel.setEnum(null)` threw NPE when clearing a previously non-null value.
- `Keypad.replaceKey(...)` re-ran `init()` without clearing existing children, duplicating the rendered keypad.

**Minor:**
- `LocaleCombobox` / `TimeZoneCombobox` `setSelected(String)` compared strings with `!=` instead of `.equals()`.
- `ChartjsData.setLabels(String...)` appended to the existing labels list instead of replacing it, unlike the `List<String>` overload of the same name.
- `Alert.setType(...)` produced an `"icon null"` sclass for unrecognized/default alert types.

## Test plan
- [x] `mvn clean compile` succeeds
- [x] `mvn test` passes
- [x] Manually reproduced and confirmed the fix for the two critical `Dataset`/`ChartjsData` bugs by compiling and running the actual code against the real ZK 10.2.1 classes:
  - Before: `"colorPalette":tools.dynamia.zk.ui.chartjs.ChartjsColorPalette@...` (invalid JSON) and `backgroundColors` with 4 entries for 2 data points
  - After: valid JSON with no `colorPalette` leak and `backgroundColors` correctly aligned 1:1 with data points
- [ ] No UI/browser test was performed (this is a server-side component library with no runnable demo app in this repo)


---
_Generated by [Claude Code](https://claude.ai/code/session_011A6euSoPhimnXurZ4icvBD)_